### PR TITLE
Bugfix/adam/enabling menu items

### DIFF
--- a/lib/negative-menu.js
+++ b/lib/negative-menu.js
@@ -14,9 +14,7 @@ let template = null;
 
 module.exports = {
 	init(negative) {
-		ipcMain.on('refresh-menu', (evt, menuStates) => {
-			this.refresh(menuStates);
-		});
+		ipcMain.on('refresh-menu', (evt, menuStates) => this.refresh(menuStates));
 
 		template = [
 			{

--- a/lib/negative-menu.js
+++ b/lib/negative-menu.js
@@ -36,8 +36,8 @@ module.exports = {
 					{ label: 'New Window',   accelerator: 'Command+N',       click: negative.initNegativeWindow },
 					MENU_SEPARATOR,
 					{ label: 'Close Tab',    accelerator: 'Command+W',       click: negative.closeTab },
-					{ label: 'Close Window', accelerator: 'Shift+Command+W', role:  'close' },
-					{ label: 'Close',        accelerator: 'Command+W',       role:  'close', visible: false }
+					{ label: 'Close Window', accelerator: 'Shift+Command+W', selector: 'performClose:' },
+					{ label: 'Close',        accelerator: 'Command+W',       selector: 'performClose:', visible: false }
 				]
 			},
 			{
@@ -90,8 +90,10 @@ module.exports = {
 		Menu.setApplicationMenu(menu);
 	},
 	
-	_processFileSubmenuItems(menuStates, isSettingsWindow, fileSubmenuItems) {
+	_processFileSubmenuItems(menuStates, fileSubmenuItems, isSettingsWindow) {
 		if (fileSubmenuItems) {
+			isSettingsWindow = !!isSettingsWindow;
+			
 			for (const fileItem of fileSubmenuItems) {
 				switch (fileItem.label) {
 					case 'New Tab': 
@@ -193,7 +195,7 @@ module.exports = {
 			for (const item of template) {
 				switch (item.label) {
 					case 'File':
-						this._processFileSubmenuItems(menuStates, isSettingsWindow, item.submenu);
+						this._processFileSubmenuItems(menuStates, item.submenu, isSettingsWindow);
 						break;
 					case 'Edit':
 						this._processEditSubmenuItems(menuStates, item.submenu);

--- a/lib/negative-menu.js
+++ b/lib/negative-menu.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { 
+	app,
 	BrowserWindow, 
 	clipboard, 
 	Menu, 
@@ -23,32 +24,32 @@ module.exports = {
 				submenu: [
 					{ label: 'About Negative', selector: 'orderFrontStandardAboutPanel:' },
 					MENU_SEPARATOR,
-					{ label: 'Preferences...', accelerator: 'Command+,', click: () => negative.initSettingsWindow() },
+					{ label: 'Preferences...', accelerator: 'Command+,', click: negative.initSettingsWindow },
 					MENU_SEPARATOR,
-					{ label: 'Quit Negative',  accelerator: 'Command+Q', selector: 'terminate:' }
+					{ label: 'Quit Negative',  accelerator: 'Command+Q', click: app.quit }
 				]
 			},
 			{
 				label: 'File',
 				submenu: [
-					{ label: 'New Tab',      accelerator: 'Command+T',       click: () => negative.addTab() },
-					{ label: 'New Window',   accelerator: 'Command+N',       click: () => negative.initNegativeWindow() },
+					{ label: 'New Tab',      accelerator: 'Command+T',       click: negative.addTab },
+					{ label: 'New Window',   accelerator: 'Command+N',       click: negative.initNegativeWindow },
 					MENU_SEPARATOR,
-					{ label: 'Close Tab',    accelerator: 'Command+W',       click: () => negative.closeTab() },
-					{ label: 'Close Window', accelerator: 'Shift+Command+W', selector: 'performClose:' },
-					{ label: 'Close',        accelerator: 'Command+W',       selector: 'performClose:', visible: false }
+					{ label: 'Close Tab',    accelerator: 'Command+W',       click: negative.closeTab },
+					{ label: 'Close Window', accelerator: 'Shift+Command+W', role:  'close' },
+					{ label: 'Close',        accelerator: 'Command+W',       role:  'close', visible: false }
 				]
 			},
 			{
 				label: 'Edit',
 				submenu: [
-					{ label: 'Undo',    accelerator: 'Command+Z',         enabled: false, click: () => negative.undo() },
-					{ label: 'Redo',    accelerator: 'Shift+Command+Z',   enabled: false, click: () => negative.redo() },
+					{ label: 'Undo',    accelerator: 'Command+Z',         enabled: false, click: negative.undo },
+					{ label: 'Redo',    accelerator: 'Shift+Command+Z',   enabled: false, click: negative.redo },
 					MENU_SEPARATOR,
-					{ label: 'Copy',    accelerator: 'Command+C',         enabled: false, click: () => negative.copy() },
-					{ label: 'Paste',   accelerator: 'Command+V',         enabled: false, click: () => negative.paste() },
-					{ label: 'Capture', accelerator: 'Command+G',         enabled: true,  click: () => negative.captureRegionBehindWindow() },
-					{ label: 'Delete',  accelerator: 'Command+Backspace', enabled: false, click: () => negative.removeImage() }
+					{ label: 'Copy',    accelerator: 'Command+C',         enabled: false, click: negative.copy },
+					{ label: 'Paste',   accelerator: 'Command+V',         enabled: false, click: negative.paste },
+					{ label: 'Capture', accelerator: 'Command+G',         enabled: true,  click: negative.captureRegionBehindWindow },
+					{ label: 'Delete',  accelerator: 'Command+Backspace', enabled: false, click: negative.removeImage }
 				]
 			},
 			{
@@ -61,12 +62,12 @@ module.exports = {
 			{
 				label: 'Window',
 				submenu: [
-					{ label: 'Minimize',                accelerator: 'Command+M',           selector: 'performMiniaturize:' },
-					{ label: 'Fit Window to Image',     accelerator: 'Command+F',           enabled: false, click: () => negative.fitWindowToImage() },
-					{ label: 'Next Tab',                accelerator: 'Command+Right',       enabled: false, click: () => negative.selectNextTab() },
-					{ label: 'Previous Tab',            accelerator: 'Command+Left',        enabled: false, click: () => negative.selectPreviousTab() },
-					{ label: 'Next Tab and Resize',     accelerator: 'Shift+Command+Right', enabled: false, click: () => negative.selectNextTabAndResizeWindowToFitImage() },
-					{ label: 'Previous Tab and Resize', accelerator: 'Shift+Command+Left',  enabled: false, click: () => negative.selectPreviousTabAndResizeWindowToFitImage() },
+					{ label: 'Minimize',                accelerator: 'Command+M',           role: 'minimize' },
+					{ label: 'Fit Window to Image',     accelerator: 'Command+F',           enabled: false, click: negative.fitWindowToImage },
+					{ label: 'Next Tab',                accelerator: 'Command+Right',       enabled: false, click: negative.selectNextTab },
+					{ label: 'Previous Tab',            accelerator: 'Command+Left',        enabled: false, click: negative.selectPreviousTab },
+					{ label: 'Next Tab and Resize',     accelerator: 'Shift+Command+Right', enabled: false, click: negative.selectNextTabAndResizeWindowToFitImage },
+					{ label: 'Previous Tab and Resize', accelerator: 'Shift+Command+Left',  enabled: false, click: negative.selectPreviousTabAndResizeWindowToFitImage },
 					{
 						label: 'Move',
 						submenu: [
@@ -80,16 +81,16 @@ module.exports = {
 							{ label: 'Up by 10px',      accelerator: 'Shift+Up',    click: () => negative.move('up', 10) },
 							{ label: 'Down by 10px',    accelerator: 'Shift+Down',  click: () => negative.move('down', 10) }
 						]
-					},
-					MENU_SEPARATOR,
-					{ label: 'Bring All to Front', selector: 'arrangeInFront:' }
+					}
 				]
 			}
 		];
-		return Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+		
+		const menu = Menu.buildFromTemplate(template);
+		Menu.setApplicationMenu(menu);
 	},
 	
-	_processFileSubmenuItems(fileSubmenuItems) {
+	_processFileSubmenuItems(menuStates, isSettingsWindow, fileSubmenuItems) {
 		if (fileSubmenuItems) {
 			for (const fileItem of fileSubmenuItems) {
 				switch (fileItem.label) {
@@ -112,11 +113,11 @@ module.exports = {
 		}
 	},
 	
-	_processEditSubmenuItems(editSubmenuItems) {
+	_processEditSubmenuItems(menuStates, editSubmenuItems) {
 		if (editSubmenuItems) {
 			for (const editItem of editSubmenuItems) {
 				switch (editItem.label) {
-					case 'Undo': 
+					case 'Undo':
 						editItem.enabled = menuStates.canUndo; 
 						break;
 					case 'Redo': 
@@ -139,7 +140,7 @@ module.exports = {
 		}
 	},
 	
-	_processViewSubmenuItems(viewSubmenuItems) {
+	_processViewSubmenuItems(menuStates, viewSubmenuItems) {
 		if (viewSubmenuItems) {
 			for (const viewItem of viewSubmenuItems) {
 				switch (viewItem.label) {
@@ -154,7 +155,7 @@ module.exports = {
 		}
 	},
 	
-	_processWindowSubmenuItems(windowSubmenuItems) {
+	_processWindowSubmenuItems(menuStates, windowSubmenuItems) {
 		if (windowSubmenuItems) {
 			for (const windowItem of windowSubmenuItems) {
 				switch (windowItem.label) {
@@ -177,7 +178,7 @@ module.exports = {
 						windowItem.enabled = menuStates.canSelectPreviousTab; 
 						break;
 					case 'Move':
-						const moveSubmenuItems = windowItem.submenu.items;
+						const moveSubmenuItems = windowItem.submenu;
 						for (const moveItem of moveSubmenuItems) {
 							moveItem.enabled = menuStates.canMove;
 						}
@@ -192,20 +193,23 @@ module.exports = {
 			for (const item of template) {
 				switch (item.label) {
 					case 'File':
-						this._processFileSubmenuItems(item.submenu.items);
+						this._processFileSubmenuItems(menuStates, isSettingsWindow, item.submenu);
 						break;
 					case 'Edit':
-						this._processEditSubmenuItems(item.submenu.items);
+						this._processEditSubmenuItems(menuStates, item.submenu);
 						break;
 					case 'View':
-						this._processViewSubmenuItems(item.submenu.items);
+						this._processViewSubmenuItems(menuStates, item.submenu);
 						break;
 					case 'Window':
-						this._processWindowSubmenuItems(item.submenu.items);
+						this._processWindowSubmenuItems(menuStates, item.submenu);
 						break;
 				}
 			}
 		}
+		
+		const menu = Menu.buildFromTemplate(template);
+		Menu.setApplicationMenu(menu);
 	},
 
 	refreshForSettingsWindow() {


### PR DESCRIPTION
- Update menu items to use `role` instead of `performSelector`, except for the 'Close' menu items, which need to be hidden in some cases. Using `role` prevents updating the menu item's boolean values.
- Update the menu to use Electron 0.37.x spec
