### PR TITLE
Use `mainWindowId` to get the last focused window for next launch.

### DIFF
--- a/lib/negative.js
+++ b/lib/negative.js
@@ -62,9 +62,14 @@ module.exports = {
 			for (const key of windowsKeys) {
 				const _window = electronWindow.windows[key];
 				const windowSettings = { 
-					bounds: _window.getBounds(),
-					isFocused: _window.isFocused()
+					bounds: _window.getBounds()
 				};
+				
+				// Always set the last focused window as the window to be focused
+				// on next launch.
+				if (key === mainWindowId) {
+					windowSettings.isFocused = true;
+				}
 				
 				_window.webContents.send('window-settings-request', windowSettings);
 			}
@@ -294,7 +299,7 @@ module.exports = {
 				negative.refreshMenu();
 			`);
 
-			mainWindowId = newWindow.id;
+			mainWindowId = `${newWindow.id}`;
 		}
 	},
 	
@@ -306,7 +311,7 @@ module.exports = {
 				negative.refreshMenu();
 			`);
 
-			mainWindowId = _window.id;
+			mainWindowId = `${_window.id}`;
 		}
 	},
 


### PR DESCRIPTION
Fixed #59 
